### PR TITLE
ログイン画面表示対応

### DIFF
--- a/blog/templates/blog/login.html
+++ b/blog/templates/blog/login.html
@@ -2,7 +2,8 @@
 <!--1.　まずは親テンプレートを指定します。-->
 {% extends 'blog/base.html' %}
 <!--2. 次に親テンプレートに組み込むブロックを記述します-->
-    {%  block LoginForm %}
+<!--拡張元のbase.htmlとブロック名が異なるので真っ白の画面になってしました。こちらを対応-->
+    {%  block loginForm %}
     <form action="" method="POST">
         {% csrf_token %}
         {{ form.as_p }}

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -16,7 +16,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-app_name= "blog"
+"""　ここのURLconfの名前はアプリケーションのblogではないので以下コメントアウト　"""
+# app_name= "blog"
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
単純に拡張元のbase.htmlのブロック名とlogin.htmlのブロック名とが異なっていたため表示されなかったようです。